### PR TITLE
Fixes #28184 - Add ability to pass a callable as the storage param to FileField and ImageField

### DIFF
--- a/docs/releases/2.2.txt
+++ b/docs/releases/2.2.txt
@@ -94,30 +94,6 @@ Database backends
 
 * Added result streaming for :meth:`.QuerySet.iterator` on SQLite.
 
-Email
-~~~~~
-
-* ...
-
-File Storage
-~~~~~~~~~~~~
-
-* Added the ability to pass a callable as the storage parameter of a :class:`~django.db.models.FileField`, or
-  :class:`~django.db.models.ImageField`. This can be used to select or set up storage for the field based on settings or variables at runtime.
-  For example, where sometimes you need remote storage and sometimes you need local storage depending on the environment you are deploying to.
-  (:ticket:`28184`)
-
-File Uploads
-~~~~~~~~~~~~
-
-* ...
-
-
-Forms
-~~~~~
-
-* ...
-
 Generic Views
 ~~~~~~~~~~~~~
 

--- a/docs/releases/3.1.txt
+++ b/docs/releases/3.1.txt
@@ -248,6 +248,10 @@ File Storage
 
 * ``FileSystemStorage.save()`` method now supports :class:`pathlib.Path`.
 
+* Added the ability to pass a callable as the storage parameter of a :class:`~django.db.models.FileField`, or
+  :class:`~django.db.models.ImageField`. This can be used to select or set up storage for the field based on settings or variables at runtime.
+  For example, where sometimes you need remote storage and sometimes you need local storage depending on the environment you are deploying to.
+
 File Uploads
 ~~~~~~~~~~~~
 


### PR DESCRIPTION
This allows storage to automatically be set up with environment or settings dependent parameters at run time